### PR TITLE
Fix print_filter_* calls in documentation

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -24,8 +24,8 @@ You can list all the available filters and theirs parameters:
 
 .. code-block:: python
 
-   ms.print_filter_list()
-   ms.print_filter_parameter_list('surface_reconstruction_screened_poisson')
+   pymeshlab.print_filter_list()
+   pymeshlab.print_filter_parameter_list('surface_reconstruction_screened_poisson')
 
 And apply filters with your parameters:
 


### PR DESCRIPTION
At least with current version one cannot call `print_filter_list` and `print_filter_parameter_list` from a `MeshSet` but from the module itself.