### PR TITLE
Ubuntu 20.04 runner closed

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'

--- a/.github/workflows/CreateAndTestRelease.yml
+++ b/.github/workflows/CreateAndTestRelease.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'


### PR DESCRIPTION
This pull request updates the operating system versions used in the CI workflows to ensure compatibility with newer environments. The most important changes include updating the Ubuntu version from 20.04 to 24.04 across multiple workflow files.

Updates to CI workflows:

* [`.github/workflows/BuildAndTest.yml`](diffhunk://#diff-094dd16e144bebad889ee22ee0301a02bf2e3878970d5a66c8562bfb84da9ebeL17-R17): Changed the Ubuntu version from 20.04 to 24.04 in the job matrix. [[1]](diffhunk://#diff-094dd16e144bebad889ee22ee0301a02bf2e3878970d5a66c8562bfb84da9ebeL17-R17) [[2]](diffhunk://#diff-094dd16e144bebad889ee22ee0301a02bf2e3878970d5a66c8562bfb84da9ebeL95-R95)
* [`.github/workflows/CreateAndTestRelease.yml`](diffhunk://#diff-974e290b9a1421225254708a0f745e6794ba8cd8b255d50c35e05691e27e5716L36-R36): Updated the Ubuntu version from 20.04 to 24.04 in the job matrix. [[1]](diffhunk://#diff-974e290b9a1421225254708a0f745e6794ba8cd8b255d50c35e05691e27e5716L36-R36) [[2]](diffhunk://#diff-974e290b9a1421225254708a0f745e6794ba8cd8b255d50c35e05691e27e5716L114-R114)