### PR TITLE
ARM Runners

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-22.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-20.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -178,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-20.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -178,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'

--- a/.github/workflows/CreateAndTestRelease.yml
+++ b/.github/workflows/CreateAndTestRelease.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-22.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-22.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -152,7 +152,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -195,7 +195,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'

--- a/.github/workflows/CreateAndTestRelease.yml
+++ b/.github/workflows/CreateAndTestRelease.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-22.04', 'ubuntu22.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -152,7 +152,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'
@@ -195,7 +195,7 @@ jobs:
     strategy:
       matrix:
         pyversion: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['ubuntu-latest', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'ubuntu24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         exclude:
           - os: macos-latest
             pyversion: '3.9'


### PR DESCRIPTION
This pull request updates the CI/CD workflows to include additional operating systems for testing, specifically adding ARM architecture support for Ubuntu and updating some Ubuntu versions. The changes were made in both the `BuildAndTest.yml` and `CreateAndTestRelease.yml` workflow files.

Updates to `.github/workflows/BuildAndTest.yml`:

* Added `ubuntu-22.04-arm` to the list of operating systems in the matrix for Python versions 3.9 to 3.13. [[1]](diffhunk://#diff-094dd16e144bebad889ee22ee0301a02bf2e3878970d5a66c8562bfb84da9ebeL17-R17) [[2]](diffhunk://#diff-094dd16e144bebad889ee22ee0301a02bf2e3878970d5a66c8562bfb84da9ebeL95-R95)
* Added `ubuntu-24.04-arm` to the list of operating systems in the matrix for Python versions 3.9 to 3.13. [[1]](diffhunk://#diff-094dd16e144bebad889ee22ee0301a02bf2e3878970d5a66c8562bfb84da9ebeL137-R137) [[2]](diffhunk://#diff-094dd16e144bebad889ee22ee0301a02bf2e3878970d5a66c8562bfb84da9ebeL181-R181)

Updates to `.github/workflows/CreateAndTestRelease.yml`:

* Added `ubuntu-22.04-arm` to the list of operating systems in the matrix for Python versions 3.9 to 3.13. [[1]](diffhunk://#diff-974e290b9a1421225254708a0f745e6794ba8cd8b255d50c35e05691e27e5716L36-R36) [[2]](diffhunk://#diff-974e290b9a1421225254708a0f745e6794ba8cd8b255d50c35e05691e27e5716L114-R114)
* Added `ubuntu-24.04-arm` to the list of operating systems in the matrix for Python versions 3.9 to 3.13. [[1]](diffhunk://#diff-974e290b9a1421225254708a0f745e6794ba8cd8b255d50c35e05691e27e5716L155-R155) [[2]](diffhunk://#diff-974e290b9a1421225254708a0f745e6794ba8cd8b255d50c35e05691e27e5716L198-R198)