### PR TITLE
consistent cross-platform metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ import sysconfig
 
 # read the contents of README file
 from os import path
-import sys
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -17,12 +16,10 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 f = open("PYML_VERSION", "r")
 pymeshlabversion = f.read()
 
-install_requires = ['numpy']
-
-# if on windows, add msvc-runtime as dependency
-osused = platform.system()
-if osused == 'Windows':
-    install_requires.append('msvc-runtime')
+install_requires = [
+    'numpy',
+    'msvc-runtime ; platform_system == "Windows"',
+]
 
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel


### PR DESCRIPTION
Use PEP508 markers to express platform-dependent metadata

So that tools like uv, poetry etc - which build cross-platform lockfiles - can get the right answers